### PR TITLE
lock get-pip.py URL to correct python version

### DIFF
--- a/docker/crawler/Dockerfile
+++ b/docker/crawler/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold" &&
     libxslt1-dev zlib1g-dev libffi-dev libssl-dev python3 python3-dev
 
 # Fetch PIP install script and run
-ADD "https://bootstrap.pypa.io/get-pip.py" /tmp/get-pip.py
+ADD "https://bootstrap.pypa.io/pip/3.5/get-pip.py" /tmp/get-pip.py
 RUN python3 /tmp/get-pip.py
 
 # Cleanup


### PR DESCRIPTION
## Purpose

Updates the URL for `get-pip.py` in `Dockerfile` to one which works with the Python version provided in the specified base image.

closes: #7 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
